### PR TITLE
ci: added skip-duplicate option to nuget push

### DIFF
--- a/.github/workflows/build-and-publish-nuget-package.yml
+++ b/.github/workflows/build-and-publish-nuget-package.yml
@@ -50,4 +50,4 @@ jobs:
         run: |  
           cd ./${{ inputs.packageName }}.Package
           dotnet pack -c Release -o out  
-          dotnet nuget push ./out/*.nupkg --no-symbols
+          dotnet nuget push ./out/*.nupkg --no-symbols --skip-duplicate


### PR DESCRIPTION
This prevents build failures when we are changing something that doesn't need a new version to be published (eg. readme)