### PR TITLE
chore: updated github action versions to remove deprecated warnings

### DIFF
--- a/.github/workflows/build-and-publish-nuget-package.yml
+++ b/.github/workflows/build-and-publish-nuget-package.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup .NET Core @ Latest
         uses: actions/setup-dotnet@v1

--- a/.github/workflows/dotnet_shared_multi-architecture-build-and-test.yml
+++ b/.github/workflows/dotnet_shared_multi-architecture-build-and-test.yml
@@ -48,16 +48,16 @@ jobs:
           echo "::set-output name=image-tag-suffix::$imageTagSuffix"
 
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up QEMU
         if: steps.prepare-build.outputs.requires-emulation == 'true'
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
         with:
           platforms: arm64
 
       - name: Set up docker buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
         with:
           driver: ${{ steps.prepare-build.outputs.buildx-driver }}
 
@@ -67,7 +67,7 @@ jobs:
 
       - name: Build Unit Test docker image
         if: ${{ inputs.run-unit-tests }}
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           target: unittest
@@ -101,7 +101,7 @@ jobs:
 
       - name: Build and push to ECR
         if: ${{ inputs.build-image }}
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           platforms: |


### PR DESCRIPTION
Unfortunately rymndhng/release-on-push-action has not been updated yet